### PR TITLE
Documents one-shot npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ git clone https://github.com/niiknow/vue-datatables-net
 cd vue-datatables-net
 npm install
 ```
+                                                                                 
+or in one command:                                                               
+                                                                                 
+```                                                                              
+npm install git+https://github.com/niiknow/vue-datatables-net.git                
+```                                                                              
 
 To run locally (automatically launch firefox):
 ```


### PR DESCRIPTION
I found the one-shot version to be more convenient than the download, cd, install, cd, rm mechanism. Others may, too. There's also the `git+ssh` variant, but that didn't seem necessary.

See also https://stackoverflow.com/a/17509764/2908724