### PR TITLE
Add name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-datatables-net-test",
+  "name": "vue-datatables-net",
   "description": "Vue jQuery DataTables.net wrapper component",
   "version": "1.1.1",
   "author": "friends@niiknow.org",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-datatables-net",
+  "name": "vue-datatables-net-test",
   "description": "Vue jQuery DataTables.net wrapper component",
   "version": "1.1.1",
   "author": "friends@niiknow.org",

--- a/src/VdtnetTable.vue
+++ b/src/VdtnetTable.vue
@@ -163,6 +163,7 @@ export default {
           title: field.label || k,
           width: field.width,
           data: field.name,
+          name: field.name,
           visible: field.visible,
           className: field.className
         }


### PR DESCRIPTION
Data Tables has another attribute to the columns object that is used to generate the column data. 'name' 
Referenced here (https://datatables.net/reference/option/columns.name)

This plugin is awesome, I wanted to make it more complete is all.
