### PR TITLE
Replace template string aka backticks with single quotes …

### DIFF
--- a/src/VdtnetTable.vue
+++ b/src/VdtnetTable.vue
@@ -17,7 +17,7 @@
             :class="field.className"
           >
             <slot
-              :name="`HEAD_${field.name}`"
+              :name="'HEAD_'+field.name"
               :field="field"
               :i="i"
             >


### PR DESCRIPTION
…and concatenation

Got an invalid character error when using VdtnetTable.vue with http-vue-loader in some older browsers, e.g. IE 11. By replacing the template string to plain string concatenation, it works.

By the way ... thanks for this great vue datatables wrapper!